### PR TITLE
added error handling in xhr attempts that aren't http:200

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -78,7 +78,7 @@ function api(options, callback) {
         return callback(errorObj);
       } catch (e) {
         return callback({
-          error: "A network error occurred",
+          error: 'A network error occurred',
           statusCode: statusCode
         });
       }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -68,6 +68,21 @@ function api(options, callback) {
       return callback(err);
     }
 
+    // 'err' is used to signal library errors, not network errors,
+    // so we also need ot make sure to check what the network status
+    // code was, before we can assume everything worked fine:
+    if (res.statusCode !== 200 && callback) {
+      try {
+        var errorObj = JSON.parse(body);
+        return callback(errorObj);
+      } catch (e) {
+        return callback({
+          error: "A network error occurred",
+          statusCode: res.statusCode
+        });
+      }
+    }
+
     // Set cache
     platform.setMemStorage(key, JSON.stringify(body), true);
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -71,14 +71,15 @@ function api(options, callback) {
     // 'err' is used to signal library errors, not network errors,
     // so we also need ot make sure to check what the network status
     // code was, before we can assume everything worked fine:
-    if (res.statusCode !== 200 && callback) {
+    var statusCode = parseInt(res.statusCode, 10);
+    if (statusCode >= 400 && callback) {
       try {
         var errorObj = JSON.parse(body);
         return callback(errorObj);
       } catch (e) {
         return callback({
           error: "A network error occurred",
-          statusCode: res.statusCode
+          statusCode: statusCode
         });
       }
     }


### PR DESCRIPTION
fixes https://github.com/mozilla/webmaker-core/issues/269 by adding error handling that checks if, where there is no `xhr` (the _library_) error, whether the response has a statusCode that would signal an improper response. Anything that isn't 200 is essentially a "we cannot use this" result - when found, the `body` that we get is checked to see if it's a JSON response and if so, that will be forwarded as error to the xhr callback, otherwise a generic network error notice with the corresponding status code is sent on.
