### PR TITLE
Convert zoom/camera to use matrix

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mocha": "^2.2.1",
     "ncp": "^2.0.0",
     "npm-run-all": "^1.2.2",
+    "panzoom": "https://github.com/k88hudson/pinch.git",
     "parallelshell": "^1.1.1",
     "proxyquire": "^1.4.0",
     "rimraf": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "mocha": "^2.2.1",
     "ncp": "^2.0.0",
     "npm-run-all": "^1.2.2",
-    "panzoom": "https://github.com/k88hudson/pinch.git",
     "parallelshell": "^1.1.1",
     "proxyquire": "^1.4.0",
     "rimraf": "^2.3.2",

--- a/src/pages/project/cartzoom.js
+++ b/src/pages/project/cartzoom.js
@@ -57,19 +57,20 @@ module.exports = {
 
     // TODO: Adjust size when window resizes
     var zoom = this.getMaxPageSize();
+    var {x, y} = this.cartesian.getFocusTransform(coords, zoom);
 
     this.setState({
-      camera: this.cartesian.getFocusTransform(coords, zoom),
-      zoom,
+      matrix: [zoom, 0, 0, zoom, x, y],
       isPageZoomed: true,
       zoomedPageCoords: coords
     });
   },
 
   zoomFromPage: function () {
+    var {x, y} = this.cartesian.getFocusTransform(this.state.zoomedPageCoords, DEFAULT_ZOOM);
+
     this.setState({
-      camera: this.cartesian.getFocusTransform(this.state.zoomedPageCoords, DEFAULT_ZOOM),
-      zoom: DEFAULT_ZOOM,
+      matrix: [DEFAULT_ZOOM, 0, 0, DEFAULT_ZOOM, x, y],
       isPageZoomed: false
     });
   },
@@ -82,18 +83,26 @@ module.exports = {
    * @return {void}
    */
   zoomToSelection: function (coords) {
+    var {x, y} = this.cartesian.getFocusTransform(coords, 1);
     this.setState({
-      camera: this.cartesian.getFocusTransform(coords, 1),
-      zoom: 1,
+      matrix: [1, 0, 0, 1, x, y],
       zoomedPageCoords: coords
     });
   },
 
   zoomOut: function () {
-    this.setState({zoom: this.state.zoom / 2});
+    var matrix = this.state.matrix.slice();
+    var zoom = this.state.zoom / 2;
+    matrix[0] = zoom;
+    matrix[3] = zoom;
+    this.setState({matrix});
   },
 
   zoomIn: function () {
-    this.setState({zoom: this.state.zoom * 2});
+    var matrix = this.state.matrix.slice();
+    var zoom = this.state.zoom * 2;
+    matrix[0] = zoom;
+    matrix[3] = zoom;
+    this.setState({matrix});
   }
 };

--- a/src/pages/project/cartzoom.js
+++ b/src/pages/project/cartzoom.js
@@ -92,7 +92,7 @@ module.exports = {
 
   zoomOut: function () {
     var matrix = this.state.matrix.slice();
-    var zoom = this.state.zoom / 2;
+    var zoom = this.state.matrix[0] / 2;
     matrix[0] = zoom;
     matrix[3] = zoom;
     this.setState({matrix});
@@ -100,7 +100,7 @@ module.exports = {
 
   zoomIn: function () {
     var matrix = this.state.matrix.slice();
-    var zoom = this.state.zoom * 2;
+    var zoom = this.state.matix[0] * 2;
     matrix[0] = zoom;
     matrix[3] = zoom;
     this.setState({matrix});

--- a/src/pages/project/loader.js
+++ b/src/pages/project/loader.js
@@ -29,7 +29,9 @@ module.exports = {
       } else if (!data || !data.pages) {
         reportError('No project found...');
       } else {
-        var state = {};
+        var state = {
+          isFirstLoad: false
+        };
         var pages = this.formatPages(data.pages);
 
         // Set cartesian coordinates
@@ -38,15 +40,15 @@ module.exports = {
         state.pages = pages;
 
         var landingPage = findLandingPage(pages);
-        var focusTransform = this.cartesian.getFocusTransform(landingPage.coords, this.state.zoom);
+        var {x, y} = this.cartesian.getFocusTransform(landingPage.coords, this.state.matrix[0]);
 
-        if (this.state.params.mode === 'play' && typeof this.state.camera.x === 'undefined') {
+        if (this.state.params.mode === 'play' && typeof this.state.isFirstLoad) {
           this.zoomToPage(landingPage.coords);
         } else if (this.state.params.mode === 'edit' && !this.state.selectedEl) {
           state.selectedEl = landingPage.id;
-          state.camera = focusTransform;
-        } else if (typeof this.state.camera.x === 'undefined') {
-          state.camera = focusTransform;
+          state.matrix = [this.state.matrix[0], 0, 0, this.state.matrix[0], x, y];
+        } else if (this.state.isFirstLoad) {
+          state.matrix = [this.state.matrix[0], 0, 0, this.state.matrix[0], x, y];
         }
 
         this.setState(state);

--- a/src/pages/project/pageadmin.js
+++ b/src/pages/project/pageadmin.js
@@ -29,8 +29,10 @@ module.exports = {
         return;
       }
 
+      var currentZoom = this.state.matrix[0];
+      var {x, y} = this.cartesian.getFocusTransform(selectedPage.coords, this.state.matrix[0]);
       var newState = {
-        camera: this.cartesian.getFocusTransform(selectedPage.coords, this.state.zoom)
+        matrix: [currentZoom, 0, 0, currentZoom, x, y]
       };
 
       if (type === 'selected') {
@@ -92,9 +94,12 @@ module.exports = {
         delete json.x;
         delete json.y;
         this.cartesian.allCoords.push(coords);
+
+        var currentZoom = this.state.matrix[0];
+        var {x, y} = this.cartesian.getFocusTransform(coords, currentZoom);
         this.setState({
           pages: update(this.state.pages, {$push: [json]}),
-          camera: this.cartesian.getFocusTransform(coords, this.state.zoom),
+          matrix: [currentZoom, 0, 0, currentZoom, x, y],
           selectedEl: json.id
         });
       });
@@ -129,9 +134,12 @@ module.exports = {
       }
 
       this.cartesian.allCoords.splice(index, 1);
+      var newZoom = this.state.matrix[0] >= MAX_ZOOM ? DEFAULT_ZOOM : this.state.matrix[0];
+      var x = this.state.matrix[4];
+      var y = this.state.matrix[5];
       this.setState({
         pages: update(this.state.pages, {$splice: [[index, 1]]}),
-        zoom: this.state.zoom >= MAX_ZOOM ? DEFAULT_ZOOM : this.state.zoom,
+        matrix: [newZoom, 0, 0, newZoom, x, y],
         selectedEl: ''
       });
     });

--- a/src/pages/project/project.jsx
+++ b/src/pages/project/project.jsx
@@ -35,9 +35,9 @@ var Project = React.createClass({
       loading: true,
       selectedEl: '',
       pages: [],
-      camera: {},
-      zoom: Project.DEFAULT_ZOOM,
-      isPageZoomed: false
+      matrix: Project.DEFAULT_ZOOM, 0, 0, Project.DEFAULT_ZOOM, 0, 0 ],
+      isPageZoomed: false,
+      isFirstLoad: true
     };
   },
 
@@ -63,8 +63,7 @@ var Project = React.createClass({
         if (state.params && state.params.project === this.state.params.project) {
           this.setState({
             selectedEl: state.selectedEl,
-            camera: state.camera,
-            zoom: state.zoom
+            state.matrix
           });
         }
       }

--- a/src/pages/project/project.jsx
+++ b/src/pages/project/project.jsx
@@ -35,7 +35,7 @@ var Project = React.createClass({
       loading: true,
       selectedEl: '',
       pages: [],
-      matrix: Project.DEFAULT_ZOOM, 0, 0, Project.DEFAULT_ZOOM, 0, 0 ],
+      matrix: [Project.DEFAULT_ZOOM, 0, 0, Project.DEFAULT_ZOOM, 0, 0 ],
       isPageZoomed: false,
       isFirstLoad: true
     };
@@ -63,7 +63,7 @@ var Project = React.createClass({
         if (state.params && state.params.project === this.state.params.project) {
           this.setState({
             selectedEl: state.selectedEl,
-            state.matrix
+            matrix: state.matrix
           });
         }
       }

--- a/src/pages/project/renderhelpers.js
+++ b/src/pages/project/renderhelpers.js
@@ -11,7 +11,7 @@ module.exports = {
   },
 
   getBoundingStyle: function() {
-    var transformString = `translate(${this.state.camera.x || 0}px, ${this.state.camera.y || 0}px) scale(${this.state.zoom})`;
+    var transformString = `matrix(${this.state.matrix.join(', ')})`;
     return assign({
         transform: transformString,
         WebkitTransform: transformString,

--- a/src/pages/project/transforms.js
+++ b/src/pages/project/transforms.js
@@ -110,10 +110,9 @@ var handleTouches = function(component) {
       didMove = true;
       var touches = event.touches,
           t0 = { x: touches[0].clientX, y: touches[0].clientY },
-          zoom = component.state.zoom,
-          camera = component.state.camera,
-          cx = camera.x,
-          cy = camera.y,
+          zoom = component.state.matrix[0],
+          cx = component.state.matrix[4],
+          cy = component.state.matrix[5],
           dx = 0, dy = 0, d = false;
 
       // update scale, due to multiple finger input
@@ -160,14 +159,11 @@ var handleTouches = function(component) {
         dangerouslySetStyle(master, { transition: "" });
         if (!didMove) { return; }
         if (!component.state.isPageZoomed) {
-          var cameraUpdate = {
-            camera: {
-              x: currentX,
-              y: currentY
-            },
-            zoom: currentZoom ? currentZoom : component.state.zoom
-          };
-          component.setState(cameraUpdate);
+          var zoom = currentZoom ? currentZoom : component.state.zoom;
+          var matrixUpdate = [zoom, 0, 0, zoom, currentX, currentY];
+          component.setState({
+            matrix: matrixUpdate
+          });
           resetValues();
         }
         // This kicks in when we're at the zoomest level of zoom.
@@ -185,9 +181,9 @@ var handleTouches = function(component) {
         //              through setState() instead. The following code overloads state
         //              as a local variable, even though anything can at anytime invalidate
         //              its content because of an async render() trigger from somewhere else.
-        component.state.camera.x = currentX;
-        component.state.camera.y = currentY;
-        component.state.zoom = currentZoom;
+        component.state.matrix[4] = currentX;
+        component.state.matrix[5] = currentY;
+        component.state.matrix[0] = currentZoom;
       }
     }
   };

--- a/src/pages/project/transforms.js
+++ b/src/pages/project/transforms.js
@@ -80,10 +80,12 @@ var handleTouches = function(component) {
    * @return {[type]}       [description]
    */
   var handleTouchStart = (event) => {
+
     if (!component.state.isPageZoomed) {
       didMove = false;
       var touches = event.touches,
           t0 = { x: touches[0].clientX, y: touches[0].clientY };
+
       // multiple fingers
       if (touches.length > 1) {
         startDX = touches[1].clientX - t0.x;
@@ -134,9 +136,7 @@ var handleTouches = function(component) {
       endY = t0.y;
 
       // and finally, bind the transform
-      var translation = 'translate(' + currentX + 'px, ' + currentY + 'px)',
-          scale = 'scale(' + zoom + ')',
-          transform = [translation, scale].join(' ');
+      var transform = `matrix(${zoom}, 0, 0, ${zoom}, ${currentX}, ${currentY})`;
       dangerouslySetStyle(master, {
         transform: transform,
         WebkitTransform: transform
@@ -159,8 +159,9 @@ var handleTouches = function(component) {
         dangerouslySetStyle(master, { transition: "" });
         if (!didMove) { return; }
         if (!component.state.isPageZoomed) {
-          var zoom = currentZoom ? currentZoom : component.state.zoom;
+          var zoom = currentZoom ? currentZoom : component.state.matrix[0];
           var matrixUpdate = [zoom, 0, 0, zoom, currentX, currentY];
+
           component.setState({
             matrix: matrixUpdate
           });

--- a/src/tests/spec.test.js
+++ b/src/tests/spec.test.js
@@ -85,7 +85,7 @@ describe('Spec', () => {
         WebkitTransform: 'translate(50px, -12px) rotate(90deg) scale(2.5)',
         transform: 'translate(50px, -12px) rotate(90deg) scale(2.5)',
         transformOrigin: 'center',
-        WebkitTransformOrigin: 'center'
+        WebkitTransformOrigin: 'center',
         zIndex: 5
       });
     });


### PR DESCRIPTION
Use a css matrix will make improving the origin stuff a lot easier; I wanted to do this step separately so the PR is smaller.

The way it works is pretty simple, 2D matrices are just 6 numbers:

```
[scaleX, 0, 0, scaleY, transformX, transformY]
```

To test, just try the project view (there should be no changes in UX)
