### PR TITLE
Pan-zoom improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ncp": "^2.0.0",
     "npm-run-all": "^1.2.2",
     "parallelshell": "^1.1.1",
+    "panzoom": "https://github.com/k88hudson/panzoom.git#b3b698d44ed12129c723f76efbd431678a34d96a",
     "proxyquire": "^1.4.0",
     "rimraf": "^2.3.2",
     "should": "^5.2.0",

--- a/src/pages/project/pageadmin.js
+++ b/src/pages/project/pageadmin.js
@@ -109,7 +109,6 @@ module.exports = {
   removePage: function () {
     var currentId = this.state.selectedEl;
     var index;
-    this.setState({loading: true});
     this.state.pages.forEach((el, i) => {
       if (el.id === currentId) {
         index = i;
@@ -123,6 +122,8 @@ module.exports = {
     if (parseInt(currentId, 10) === 1) {
       return window.alert('this is a test page, not deleting.');
     }
+
+    this.setState({loading: true});
 
     api({
       method: 'delete',

--- a/src/pages/project/transforms.js
+++ b/src/pages/project/transforms.js
@@ -1,202 +1,33 @@
-var assign = require('react/lib/Object.assign');
-var calculateSwipe = require('../../lib/swipe.js');
+var Panzoom = require('panzoom');
 
 var MAX_ZOOM = 0.5;
 var MIN_ZOOM = 0.18;
-var ZOOM_SENSITIVITY = 300;
-
-/**
- * Directly manipulate an element's style, rather than changing it through render()
- */
-function dangerouslySetStyle(element, style) {
-  assign(element.style, style);
-}
-
-/**
- * utility function for constraining a value
- */
-function constrain(v,min,max) {
-  return v<min ? min : v>max ? max : v;
-}
-
-/**
- * Touch handler for projects
- */
-var handleTouches = function(component) {
-  var node = component.getDOMNode();
-  var master = component.refs.bounding.getDOMNode();
-
-  // administrative values:
-  var didMove = false,
-      startX,
-      startY,
-      startDX = 0,
-      startDY = 0,
-      startDistance,
-      endX,
-      endY,
-      currentX,
-      currentY,
-      currentZoom;
-
-  // partial reset, used by handleTouchEnd
-  var resetValues = function() {
-    startX = undefined;
-    startY = undefined;
-    startDX = 0;
-    startDY = 0;
-    startDistance = undefined;
-    currentX = undefined;
-    currentY = undefined;
-    currentZoom = undefined;
-  };
-
-  // Swipe handling is supposed to kick in for... something...
-  var handleSwipe = () => {
-    var swipeDirection = calculateSwipe(startX, startY, endX, endY);
-    if (swipeDirection) {
-      var coords = component.state.zoomedPageCoords,
-          cx = coords.x,
-          cy = coords.y;
-      var panTargets = {
-        LEFT:  { x: cx + 1, y: cy     },
-        RIGHT: { x: cx - 1, y: cy     },
-        UP:    { x: cx,     y: cy + 1 },
-        DOWN:  { x: cx,     y: cy - 1 }
-      };
-      var target = panTargets[swipeDirection];
-      // Determine if the desired adjacent page exists
-      var pages = component.state.pages;
-      if (pages.some(p => p.coords.x === target.x && p.coords.y === target.y)) {
-        component.zoomToPage(target);
-      }
-    }
-  };
-
-
-  /**
-   * [description]
-   * @param  {[type]} event [description]
-   * @return {[type]}       [description]
-   */
-  var handleTouchStart = (event) => {
-
-    if (!component.state.isPageZoomed) {
-      didMove = false;
-      var touches = event.touches,
-          t0 = { x: touches[0].clientX, y: touches[0].clientY };
-
-      // multiple fingers
-      if (touches.length > 1) {
-        startDX = touches[1].clientX - t0.x;
-        startDY = touches[1].clientY - t0.y;
-        startDistance = Math.sqrt(startDX*startDX + startDY*startDY);
-      }
-      // single finger
-      else {
-        startX = t0.x;
-        startY = t0.y;
-        dangerouslySetStyle(master, { transition: "none" });
-      }
-      // interaction continues in handleTouchMove
-    }
-  };
-
-  /**
-   * [description]
-   * @param  {[type]} event [description]
-   * @return {[type]}       [description]
-   */
-  var handleTouchMove = (event) => {
-    if (!component.state.isPageZoomed) {
-      didMove = true;
-      var touches = event.touches,
-          t0 = { x: touches[0].clientX, y: touches[0].clientY },
-          zoom = component.state.matrix[0],
-          cx = component.state.matrix[4],
-          cy = component.state.matrix[5],
-          dx = 0, dy = 0, d = false;
-
-      // update scale, due to multiple finger input
-      if (touches.length > 1) {
-        dx = touches[1].clientX - t0.x;
-        dy = touches[1].clientY - t0.y;
-
-        d  = Math.sqrt(dx*dx + dy*dy);
-        currentZoom = constrain( zoom + (d-startDistance)/ZOOM_SENSITIVITY, MIN_ZOOM, MAX_ZOOM);
-        zoom = currentZoom;
-      }
-
-      // update translation, corrected for our zoom center
-      currentX = cx + (t0.x - startX) + (dx - startDX);
-      currentY = cy + (t0.y - startY) + (dy - startDY);
-
-      // update tracking value
-      endX = t0.x;
-      endY = t0.y;
-
-      // and finally, bind the transform
-      var transform = `matrix(${zoom}, 0, 0, ${zoom}, ${currentX}, ${currentY})`;
-      dangerouslySetStyle(master, {
-        transform: transform,
-        WebkitTransform: transform
-      });
-    }
-
-  };
-
-  /**
-   * [description]
-   * @param  {[type]} event [description]
-   * @return {[type]}       [description]
-   */
-  var handleTouchEnd = (event) => {
-    if (!component.state.isPageZoomed) {
-      var touches = event.touches;
-
-      // there are no more fingers on the screen
-      if (touches.length === 0) {
-        dangerouslySetStyle(master, { transition: "" });
-        if (!didMove) { return; }
-        if (!component.state.isPageZoomed) {
-          var zoom = currentZoom ? currentZoom : component.state.matrix[0];
-          var matrixUpdate = [zoom, 0, 0, zoom, currentX, currentY];
-
-          component.setState({
-            matrix: matrixUpdate
-          });
-          resetValues();
-        }
-        // This kicks in when we're at the zoomest level of zoom.
-        // On a phone: page view. On a Nexus 7: nothing like page view.
-        else { handleSwipe(); }
-      }
-      // there fingers left on the screen
-      else {
-        startX = touches[0].clientX;
-        startY = touches[0].clientY;
-        startDX = 0;
-        startDY = 0;
-        // FIXME: TODO: we should not do this. We cannot modify "state" unless we intend
-        //              for that to immediately cause a render(), which means setting them
-        //              through setState() instead. The following code overloads state
-        //              as a local variable, even though anything can at anytime invalidate
-        //              its content because of an async render() trigger from somewhere else.
-        component.state.matrix[4] = currentX;
-        component.state.matrix[5] = currentY;
-        component.state.matrix[0] = currentZoom;
-      }
-    }
-  };
-
-  node.addEventListener('touchstart', handleTouchStart);
-  node.addEventListener('touchmove', handleTouchMove);
-  node.addEventListener('touchend', handleTouchEnd);
-};
-
 
 module.exports = {
   componentDidMount: function () {
-    handleTouches(this);
+    var pz = new Panzoom(this.refs.bounding.getDOMNode(), {
+      minScale: MIN_ZOOM,
+      maxScale: MAX_ZOOM,
+      onEnd: (e) => {
+        var matrix = pz.getMatrix();
+        this.setState({matrix});
+      }
+    });
+    this.panzoom = pz;
+    if (this.state.isPageZoomed) {
+      pz.disable();
+    }
+  },
+  componentDidUpdate: function (prevProps, prevState) {
+
+    // Disable panzoom if state goes from zoomedIn to not zoomedIn
+    if (this.panzoom && this.state.isPageZoomed && !prevState.isPageZoomed) {
+      this.panzoom.disable();
+    }
+
+    // Disable if state goes from zoomedIn to not zoomedIn
+    if (this.panzoom && !this.state.isPageZoomed  && prevState.isPageZoomed) {
+      this.panzoom.enable();
+    }
   }
 };


### PR DESCRIPTION
Blocked on landing https://github.com/mozilla/webmaker-core/pull/377

TODO:
- panning does not continue after a zoom, that still needs to be implemented -- i think this is a significant enough improvement we could file as a follow-up though
- there seems to be a problem with restoring the matrix from memory on edit mode
