### PR TITLE
Change over page and element edits to an offline experience with single bulk sync call on exit

### DIFF
--- a/src/components/link/link.jsx
+++ b/src/components/link/link.jsx
@@ -14,6 +14,12 @@ var Link = React.createClass({
       onClick: (e) => {
         if (window.Platform) {
           e.preventDefault();
+
+          // if there is a pre-navigation handling hook, call that before continuing
+          if (this.props.preNavigation && typeof this.props.preNavigation === 'function') {
+            this.props.preNavigation();
+          }
+
           if (this.props.external) {
             window.Platform.openExternalUrl(this.props.external);
           } else if (this.props.url) {

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -62,6 +62,16 @@ Platform.prototype.clearUserSession = function() {
 };
 
 // -----------------------------------------------------------------------------
+// Java caching
+// -----------------------------------------------------------------------------
+
+Platform.prototype.getAPI = function() {
+  // True only if platform was supplied via the Android "windows.Platform"
+  // mechanism, otherwise this is very much false.
+  return false;
+};
+
+// -----------------------------------------------------------------------------
 // Memory (LRU) storage
 // -----------------------------------------------------------------------------
 

--- a/src/pages/element/image-editor.jsx
+++ b/src/pages/element/image-editor.jsx
@@ -101,9 +101,9 @@ var ImageEditor = React.createClass({
   },
   imageReady: function (uri) {
     this.setState({
-      src: uri
+      src: uri,
+      loading: false
     });
-    this.props.save();
   }
 });
 

--- a/src/pages/make/make.jsx
+++ b/src/pages/make/make.jsx
@@ -67,30 +67,65 @@ var Make = React.createClass({
     }
 
     this.setState({loading: true});
+
+    // we will be creating a new project
+    var createProject = {
+      method: "create",
+      type: "projects",
+      data: {
+        title: defaultTitle
+      }
+    };
+
+    // and for user convenience, new projects should start with an empty page
+    var createFirstPage = {
+      method: "create",
+      type: "pages",
+      data: {
+        projectId: "$0.id",
+        x: 0,
+        y: 0,
+        styles: {}
+      }
+    };
+
     api({
       method: 'post',
-      uri: `/users/${user.id}/projects`,
+      uri: `/users/${user.id}/bulk`,
       json: {
-        title: defaultTitle
+        actions: [
+          createProject,
+          createFirstPage
+        ]
       }
     }, (err, body) => {
       if (err) {
         return this.onError(err);
       }
-      if (!body || !body.project) {
+
+      // the bulk API sends back results in a number array, where each position
+      // in the result set corresponds to the same position in the list of actions
+      // that had to be performed "in bulk". As such, the "create project" result
+      // will be in body.results[0], and the "create page" result will be in
+      // body.results[1]
+
+      if (!body || !body.results || body.results.length === 0) {
         return this.onEmpty();
       }
 
-      platform.trackEvent('Make', 'Create a Project', 'New Project Started');
-      platform.setView('/users/' + user.id + '/projects/' + body.project.id);
+      var project = body.results[0];
+      project.author = project.author || user;
 
-      body.project.author = body.project.author || user;
+      platform.trackEvent('Make', 'Create a Project', 'New Project Started');
 
       this.setState({
         loading: false,
-        projects: [body.project].concat(this.state.projects)
+        projects: this.state.projects.concat([project])
+      }, function() {
+        platform.setView('/users/' + user.id + '/projects/' + project.id);
       });
     });
+
   },
 
   logout: function () {

--- a/src/pages/page/loader.js
+++ b/src/pages/page/loader.js
@@ -1,0 +1,203 @@
+var api = require('../../lib/api');
+var platform = require('../../lib/platform');
+var reportError = require('../../lib/errors');
+
+module.exports = {
+  componentWillMount: function() {
+    this.loadComponentData();
+  },
+
+  componentDidUpdate: function (prevProps, prevState) {
+    // resume
+    if (this.props.isVisible && !prevProps.isVisible) {
+      this.checkCache();
+    }
+  },
+
+  loadComponentData: function() {
+    this.setState({loading: false});
+
+    if (this.checkCache()) {
+      return this.setState({loading: false});
+    }
+
+    api({ uri: this.uri() }, (err, data) => {
+      this.setState({loading: false});
+
+      if (err) {
+        return reportError(this.getIntlMessage('error_page'), err);
+      }
+
+      if (!data || !data.page) {
+        return reportError(this.getIntlMessage('error_page_404'));
+      }
+
+      var page = data.page;
+      var styles = page.styles;
+      var elements = {};
+
+      page.elements.forEach(element => {
+        element = this.flatten(element);
+        if(element) {
+          elements[element.id] = element;
+        }
+      });
+
+      this.setState({
+        styles,
+        elements
+      });
+    });
+  },
+
+  checkCache: function() {
+    var java = platform.getAPI();
+
+    if (java) {
+      var elements = this.state.elements;
+      var payloads = java.getPayloads("edited-element");
+      var failed = 0;
+
+      // TODO: FIXME: DRY this code out, since we're effectively doing
+      //              the same thing for keys "edited-element", from the
+      //              element editor, and for key "edit-element", from the
+      //              projects page (after setting destination)
+
+      if (payloads !== undefined) {
+        try {
+          payloads = JSON.parse(payloads);
+          payloads.forEach(payload => {
+            var update = payload.data;
+            update = this.flatten(update);
+            elements[update.id] = update;
+            this.queueEdit(update.id);
+          });
+
+          java.clearPayloads("edited-element");
+          this.setState({
+            loading: false,
+            elements: elements
+          });
+        } catch (e) {
+          console.error("malformed payload JSON:", payloads);
+        }
+      } else { failed++; }
+
+      payloads = java.getPayloads("edit-element");
+      if (payloads !== undefined) {
+        try {
+          payloads = JSON.parse(payloads);
+          var update = payloads[0].data;
+          update = this.flatten(update);
+          elements[update.id] = update;
+          this.queueEdit(update.id);
+
+          java.clearPayloads("edit-element");
+          this.setState({
+            loading: false,
+            elements: elements
+          });
+        } catch (e) {
+          console.error("malformed payload JSON after setDestination:", payloads);
+        }
+      } else { failed++; }
+
+      if (failed < 2) {
+        return true;
+      }
+    }
+
+    return false;
+  },
+
+  addSaveActions: function (actions, elementId) {
+    var pageId = this.state.params.page;
+
+    var element = this.state.elements[elementId];
+    element = this.expand(element);
+
+    // new elements require a CREATE action
+    if (element.newlyCreated) {
+      delete element.newlyCreated;
+
+      actions.push({
+        method: "create",
+        type: "elements",
+        data: {
+          pageId: pageId,
+          type: element.type,
+          styles: element.styles,
+          attributes: element.attributes
+        }
+      });
+    }
+
+    // existing elements require a PATCH action
+    else {
+      actions.push({
+        method: "update",
+        type: "elements",
+        data: {
+          id: elementId,
+          styles: element.styles,
+          attributes: element.attributes
+        }
+      });
+    }
+  },
+
+  saveEntirePage: function(callAfterSaving) {
+    if (this.edits.length > 0) {
+
+      var actions = [];
+      var elements = this.state.elements;
+
+      // cascading build function
+      var processNext = (ids) => {
+        if(ids.length === 0) {
+          return this.processBulkOperations(actions, callAfterSaving);
+        }
+
+        var id = ids.splice(0,1)[0];
+
+        // If this element is still found in the page elements,
+        // then this is a create and/or update operation.
+        if (this.state.elements[id]) {
+          this.addSaveActions(actions, id);
+        }
+
+        // If it is not, then the element was deleted:
+        else {
+          actions.push({
+            method: "remove",
+            type: "elements",
+            data: {
+              id: id
+            }
+          });
+        }
+
+        processNext(ids);
+      };
+      // initiate cascade
+      processNext(this.edits);
+    } else { callAfterSaving(); }
+  },
+
+  processBulkOperations: function(actions, callAfterHandling) {
+    var userId = this.state.params.user;
+    api({
+      method: 'post',
+      uri: `/users/${userId}/bulk`,
+      json: { actions: actions }
+    }, (err, body) => {
+      if (err) {
+        return this.onError(err);
+      }
+
+      if (callAfterHandling) {
+        setTimeout(callAfterHandling, 1);
+      }
+    });
+  }
+};

--- a/src/pages/page/page-controls.jsx
+++ b/src/pages/page/page-controls.jsx
@@ -1,9 +1,27 @@
 var React = require('react');
 var classNames = require('classnames');
-
 var Link = require('../../components/link/link.jsx');
+var platform = require('../../lib/platform');
 
 var PageControls = React.createClass({
+
+  mixins: [
+    require("./flattening")
+  ],
+
+  cacheElementForEdits: function(evt) {
+    // cache the element on the java side
+    var java = platform.getAPI();
+    if (java) {
+      var element = this.props.currentElement;
+      if (element) {
+        java.queue("edit-element", JSON.stringify({
+          data: this.expand(element)
+        }));
+      }
+    }
+  },
+
   secondaryButtonClass: function(name) {
     var names = {
       secondary: true,
@@ -27,6 +45,7 @@ var PageControls = React.createClass({
         <button className="add" onClick={this.props.toggleAddMenu}></button>
         <Link
           className={this.secondaryButtonClass("edit")}
+          preNavigation={this.cacheElementForEdits}
           url={this.props.url}
           href={this.props.href}>
           <img className="icon" src="../../img/brush.svg" />

--- a/src/pages/project/loader.js
+++ b/src/pages/project/loader.js
@@ -1,5 +1,7 @@
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 var reportError = require('../../lib/errors');
+var types = require('../../components/basic-element/basic-element.jsx').types;
 
 function findLandingPage(pages) {
   var result;
@@ -54,10 +56,17 @@ module.exports = {
         this.setState(state);
 
         // Highlight the source page if you're in link destination mode
-        if (this.state.params.mode === 'link') {
-          if (window.Platform) {
-            this.highlightPage(this.state.routeData.pageID, 'source');
-          }
+        var java = platform.getAPI();
+        if (java) {
+          var payloads = java.getPayloads("link-element");
+          // do NOT clear the payload, we do that in setdestination.js instead
+          var list = JSON.parse(payloads);
+          var element = types.link.spec.expand(list[0].data);
+          var pageId = element.attributes.targetPageId;
+          if (pageId) { this.highlightPage(pageId, 'source'); }
+        }
+        else if (this.state.params.mode === 'link') {
+          this.highlightPage(this.state.routeData.pageID, 'source');
         }
       }
     });

--- a/src/pages/project/setdestination.js
+++ b/src/pages/project/setdestination.js
@@ -1,5 +1,6 @@
 var types = require('../../components/basic-element/basic-element.jsx').types;
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 var reportError = require('../../lib/errors');
 var dispatcher = require('../../lib/dispatcher');
 
@@ -16,31 +17,56 @@ module.exports = {
   },
 
   setDestination: function () {
-    var patchedState = this.state.routeData.linkState;
+    var java = platform.getAPI();
 
-    patchedState = types.link.spec.expand(patchedState);
+    // If we have java caching available, there should be a link-element in cache
+    if(java) {
+      var payloads = java.getPayloads("link-element");
+      java.clearPayloads("link-element");
 
-    // Patch old attributes object to prevent overwritten properties
-    patchedState.attributes.targetPageId = this.state.selectedEl;
-    patchedState.attributes.targetProjectId = this.state.params.project;
-    patchedState.attributes.targetUserId = this.state.params.user;
+      var list = JSON.parse(payloads);
+      var element = types.link.spec.expand(list[0].data);
+      element.attributes.targetPageId    = this.state.selectedEl;
+      element.attributes.targetProjectId = this.state.params.project;
+      element.attributes.targetUserId    = this.state.params.user;
 
-    this.setState({loading: true});
-    api({
-      method: 'patch',
-      uri: `/users/${this.state.routeData.userID}/projects/${this.state.routeData.projectID}/pages/${this.state.routeData.pageID}/elements/${this.state.routeData.elementID}`,
-      json: {
-        attributes: patchedState.attributes
-      }
-    }, (err, data) => {
-      this.setState({loading: false});
-      if (err) {
-        reportError('There was an error updating the element', err);
-      }
+      var serialized = JSON.stringify({
+        data: element
+      });
+      java.queue("edit-element", serialized);
+      platform.goBack();
+    }
 
-      if (window.Platform) {
-        window.Platform.goBack();
-      }
-    });
+    // fall back to the original API way of doing things
+    else {
+
+      var patchedState = this.state.routeData.linkState;
+
+      patchedState = types.link.spec.expand(patchedState);
+
+      // Patch old attributes object to prevent overwritten properties
+      patchedState.attributes.targetPageId = this.state.selectedEl;
+      patchedState.attributes.targetProjectId = this.state.params.project;
+      patchedState.attributes.targetUserId = this.state.params.user;
+
+      this.setState({loading: true});
+      api({
+        method: 'patch',
+        uri: `/users/${this.state.routeData.userID}/projects/${this.state.routeData.projectID}/pages/${this.state.routeData.pageID}/elements/${this.state.routeData.elementID}`,
+        json: {
+          attributes: patchedState.attributes
+        }
+      }, (err, data) => {
+        this.setState({loading: false});
+        if (err) {
+          reportError('There was an error updating the element', err);
+        }
+
+        if (window.Platform) {
+          window.Platform.goBack();
+        }
+      });
+    }
+
   }
 };


### PR DESCRIPTION
This code switches the following page operations from "routed through api.wmo for every operation" to a queued modification system, where all modifications are aggregated and then communicated all at once to api.wmo when the page view is left to return to the project view:
1. element creation
2. element deletion
3. element modification en-place (translation, rotation, zoom)
4. element modification by using the "edit" functionality

This patch relies on work done in https://github.com/cadecairos/api.webmaker.org/tree/bulk, as well as on https://github.com/pomax/webmaker-android/tree/javaapi. The first for obvious reasons, the second for a Java/JS bridge that allows any view to short-term cache data (keyed by a namespacing string) on the Java side while the app switching out its WebViews, so that the new view can retrieve the cached data and continue working with it. This is specifically used to allow a page to cache the "to edit" element on the Java side of our app, so that the Element editor view can then pluck it out of cache, for users to modify. Returning to the Page view then runs the process in reverse, caching the edited element in Java, which the page view can then fetch back out and update itself accordingly.

Detailed instructions on how this patch can be tested in full can be found in the following gist: https://gist.github.com/Pomax/ef669245d93e3cba4bf4

The diagrams of how things work, with java-caching and bulk-save when leaving "page" for "project:

![page-01](https://cloud.githubusercontent.com/assets/177243/8913276/ec4babbe-344c-11e5-8fdf-17d9f7473cdb.jpg)

Updates via the element editor follow the same "track change, only save as part of pre-leave-bulk-call" concept, but getting the data into, and out of, the element editor is a little more work:

![page-2](https://cloud.githubusercontent.com/assets/177243/8913294/0b16f0bc-344d-11e5-8037-8d7995dbc334.jpg)

Updates via tinker mode call `save` on the element before changing view to Tinker mode, so tinker mode simply checks java for data in the `edited-element` cache bin, and puts data back as `edit-element` (these correspond to what element.jsx and page.jsx use, too):

![d2](https://cloud.githubusercontent.com/assets/177243/9016238/43fec3ca-3784-11e5-9566-6580254acd85.jpg)

Updates to the `link button` destination can occur in two different ways, one initiated via the link editor, the other via the "set destination" button while in page view:

![destination](https://cloud.githubusercontent.com/assets/177243/9070389/4034794c-3aa4-11e5-876e-1bc005fb4a36.jpg)
