### PR TITLE
[#419] use onError instead of react-imageloader

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "panzoom": "https://github.com/k88hudson/panzoom.git#b3b698d44ed12129c723f76efbd431678a34d96a",
     "react": "0.13.1",
     "react-hammerjs": "0.2.2",
-    "react-imageloader": "1.2.0",
     "react-intl": "1.2.0",
     "xhr": "2.0.1"
   },

--- a/src/components/card/card.jsx
+++ b/src/components/card/card.jsx
@@ -18,12 +18,13 @@ var Card = React.createClass({
   componentDidMount: function () {
     var imageEl = this.refs.imageEl.getDOMNode();
     imageEl.onerror = this.onImageError;
+    imageEl.src = this.props.thumbnail || Card.DEFAULT_THUMBNAIL;
   },
   render: function () {
     return (
       <Link url={this.props.url} href={this.props.href} className="card">
         <div className="thumbnail">
-          <img ref="imageEl" src={this.props.thumbnail || Card.DEFAULT_THUMBNAIL} />
+          <img ref="imageEl" />
         </div>
 
         <div className="meta">

--- a/src/components/card/card.jsx
+++ b/src/components/card/card.jsx
@@ -1,5 +1,4 @@
 var React = require('react/addons');
-var ImageLoader = require('react-imageloader');
 var Link = require('../link/link.jsx');
 
 var Card = React.createClass({
@@ -11,16 +10,20 @@ var Card = React.createClass({
     e.stopPropagation();
     this.props.onActionsClick.call(this, this.props);
   },
-  prerenderImage: function() {
-    return React.createElement('img', {
-      src: Card.DEFAULT_THUMBNAIL
-    });
+  onImageError: function() {
+    var imageEl = this.refs.imageEl.getDOMNode();
+    imageEl.src = Card.DEFAULT_THUMBNAIL;
+    imageEl.onerror = null;
+  },
+  componentDidMount: function () {
+    var imageEl = this.refs.imageEl.getDOMNode();
+    imageEl.onerror = this.onImageError;
   },
   render: function () {
     return (
       <Link url={this.props.url} href={this.props.href} className="card">
         <div className="thumbnail">
-          <ImageLoader src={this.props.thumbnail || Card.DEFAULT_THUMBNAIL} preloader={this.prerenderImage}></ImageLoader>
+          <img ref="imageEl" src={this.props.thumbnail || Card.DEFAULT_THUMBNAIL} />
         </div>
 
         <div className="meta">

--- a/src/components/card/card.less
+++ b/src/components/card/card.less
@@ -12,7 +12,8 @@
 
   .thumbnail {
     padding: 6px 0 0 0;
-
+    height: 0;
+    padding-bottom: 61.875%;
     img {
       display: block;
       position: relative;


### PR DESCRIPTION
According to the docs, `onError` and `onLoad should be supported on image elements in React, but they don't appear to be working, so I had to attach the event manually.

@gvn what do you think?
