### PR TITLE
Better login/sign up error messages

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -85,6 +85,14 @@ api.AUTHENTICATE_URI = api.BASE_LOGIN_URI + '/login/oauth/access_token';
 api.SIGN_UP_URI = api.BASE_LOGIN_URI + '/create-user';
 api.USER_URI = api.BASE_LOGIN_URI + '/user';
 
+api.ERROR_MESSAGES = {
+  offline_sign_in: 'Please connect to the Internet to sign in.',
+  login_cant_connect: 'There was a problem connecting to the login server.',
+  wrong_username_password: 'There was a problem with your username or password.',
+  login_server_problem: 'Looks like there was a problem with the login server.',
+  offline_sign_up: 'We need an Internet connection to create an account.'
+}
+
 api.requiredOptions = function (options, requiredFields) {
 
   requiredFields = requiredFields || [];
@@ -134,6 +142,14 @@ api.authenticate = function (options, callback) {
     return callback(new Error('You must supply options.json to login'));
   }
 
+  // Check offline status
+  if (platform.isNetworkAvailable && !platform.isNetworkAvailable()) {
+    return callback({
+      statusCode: 0,
+      message: api.ERROR_MESSAGES.offline_sign_in
+    });
+  }
+
   // Add in other required fields
   var json = assign({
     client_id: config.CLIENT_ID,
@@ -150,11 +166,40 @@ api.authenticate = function (options, callback) {
     }
   }, function (err, resp, body) {
 
-    if (err || resp.statusCode !== 200) {
-      return callback(parseJSON(body));
+    body = parseJSON(body);
+
+    // There was an XMLHTTPRequest error, which could mean:
+    // 1. we are offline
+    // 2. CORS issues
+    // 3. the server is down
+    if (err || resp.statusCode === 0) {
+      return callback({
+        statusCode: resp.statusCode,
+        error: err,
+        message: api.ERROR_MESSAGES.login_cant_connect
+      });
     }
 
-    body = parseJSON(body);
+    // 400 errors indicate a problem with credentials,
+    // such as a wrong password or username
+    else if (resp.statusCode >= 400 && resp.statusCode < 500) {
+      return callback({
+        statusCode: resp.statusCode,
+        message: api.ERROR_MESSAGES.wrong_username_password
+      });
+    }
+
+    // Any other errors are probably a server problem (i.e. 500)
+    // We may get a response that is useful but is more likely
+    // not understandable by the user
+    else if (resp.statusCode !== 200) {
+      return callback({
+        statusCode: resp.statusCode,
+        message: api.ERROR_MESSAGES.login_server_problem,
+        error: body
+      });
+    }
+
     var token = body.access_token;
 
     // If we provided a user object already, just return it with the token
@@ -170,10 +215,25 @@ api.authenticate = function (options, callback) {
         Authorization: 'token ' + token
       }
     }, function (err, resp, body) {
-      if (err || resp.statusCode !== 200) {
-        return callback(parseJSON(body));
-      }
+
       body = parseJSON(body);
+
+      // There was an XMLHTTPRequest error, which could mean:
+      // 1. we are offline
+      // 2. CORS issues
+      // 3. the server is down
+      if (err || resp.statusCode === 0) {
+        return callback({
+          statusCode: resp.statusCode,
+          error: err,
+          message: api.ERROR_MESSAGES.login_cant_connect
+        });
+      }
+
+      if (resp.statusCode !== 200) {
+        return callback(body);
+      }
+
       callback(null, {token, user: body});
     });
   });
@@ -202,6 +262,14 @@ api.signUp = function (options, callback) {
     return callback(new Error('You must supply options.json to sign up'));
   }
 
+  // Check offline status
+  if (platform.isNetworkAvailable && !platform.isNetworkAvailable()) {
+    return callback({
+      statusCode: 0,
+      message: api.ERROR_MESSAGES.offline_sign_up
+    });
+  }
+
   var json = assign({
     client_id: config.CLIENT_ID
   }, options.json);
@@ -214,10 +282,36 @@ api.signUp = function (options, callback) {
       'Content-Type': 'application/x-www-form-urlencoded'
     }
   }, function (err, resp, body) {
-    if (err || resp.statusCode !== 200) {
-      return callback(parseJSON(body));
-    }
+
     body = parseJSON(body);
+
+    // There was an XMLHTTPRequest error, which could mean:
+    // 1. we are offline
+    // 2. CORS issues
+    // 3. the server is down
+    if (err || resp.statusCode === 0) {
+      return callback({
+        statusCode: resp.statusCode,
+        error: err,
+        message: api.ERROR_MESSAGES.login_cant_connect
+      });
+    }
+
+    // 400 errors should be passed to the user
+    else if (resp.statusCode >= 400 && resp.statusCode < 500) {
+      return callback(body);
+    }
+
+    // 500 responses are probably not the user's fault
+    // and likely not user-readable
+    else if (resp.statusCode !== 200) {
+      return callback({
+        statusCode: resp.statusCode,
+        message: api.ERROR_MESSAGES.login_server_problem,
+        error: body
+      });
+    }
+
     // Cool, let's authenticate now
     api.authenticate({
       user: body,

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -91,7 +91,7 @@ api.ERROR_MESSAGES = {
   wrong_username_password: 'There was a problem with your username or password.',
   login_server_problem: 'Looks like there was a problem with the login server.',
   offline_sign_up: 'We need an Internet connection to create an account.'
-}
+};
 
 api.requiredOptions = function (options, requiredFields) {
 

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -143,7 +143,7 @@ api.authenticate = function (options, callback) {
   }
 
   // Check offline status
-  if (platform.isNetworkAvailable && !platform.isNetworkAvailable()) {
+  if (!platform.isNetworkAvailable()) {
     return callback({
       statusCode: 0,
       message: api.ERROR_MESSAGES.offline_sign_in
@@ -263,7 +263,7 @@ api.signUp = function (options, callback) {
   }
 
   // Check offline status
-  if (platform.isNetworkAvailable && !platform.isNetworkAvailable()) {
+  if (!platform.isNetworkAvailable()) {
     return callback({
       statusCode: 0,
       message: api.ERROR_MESSAGES.offline_sign_up

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -167,5 +167,4 @@ Platform.prototype.isDebugBuild = function() {
   return false;
 };
 
-
 module.exports = new Platform();

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -173,7 +173,7 @@ Platform.prototype.isDebugBuild = function() {
 
 Platform.prototype.isNetworkAvailable = function() {
   // @todo - the android method is synchronous, we need to do the browser chekc async 
-  return true
+  return true;
 };
 
 module.exports = new Platform();

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -167,4 +167,13 @@ Platform.prototype.isDebugBuild = function() {
   return false;
 };
 
+// -----------------------------------------------------------------------------
+// Check network availability
+// -----------------------------------------------------------------------------
+
+Platform.prototype.isNetworkAvailable = function() {
+  // @todo - the android method is synchronous, we need to do the browser chekc async 
+  return true
+};
+
 module.exports = new Platform();

--- a/src/pages/login/sign-in.jsx
+++ b/src/pages/login/sign-in.jsx
@@ -74,6 +74,8 @@ var SignIn = React.createClass({
   onSubmit: function (e) {
     e.preventDefault();
 
+    document.activeElement.blur();
+
     var errors = this.getValidationErrors();
     if (Object.keys(errors).length > 0) {
       return;
@@ -133,7 +135,7 @@ var SignIn = React.createClass({
           valueLink={this.linkState(field.name)} />;
       })}
       <div className="form-group">
-        <button className="btn btn-block" disabled={!isValid} onClick={this.onSubmit}>
+        <button ref="submitButton" className="btn btn-block" disabled={!isValid} onClick={this.onSubmit}>
           {this.getIntlMessage('signin')}
         </button>
         <div className="error" hidden={!this.state.globalError}>

--- a/src/pages/login/sign-in.jsx
+++ b/src/pages/login/sign-in.jsx
@@ -1,5 +1,4 @@
 var React = require('react/addons');
-var reportError = require('../../lib/errors');
 var api = require('../../lib/api');
 var keyboard = require('../../lib/keyboard');
 
@@ -92,8 +91,9 @@ var SignIn = React.createClass({
         if (window.Platform) {
           window.Platform.trackEvent('Login', 'Sign In', 'Sign In Error');
         }
-        this.setState({globalError: true});
-        return reportError("Error while trying to log in", err);
+        this.setState({globalError: err.message || 'Something went wrong.'});
+        console.log(err);
+        return;
       }
 
       this.replaceState(this.getInitialState());
@@ -137,7 +137,7 @@ var SignIn = React.createClass({
           {this.getIntlMessage('signin')}
         </button>
         <div className="error" hidden={!this.state.globalError}>
-          {this.getIntlMessage('errorUsernameOrPassword')}
+          {this.state.globalError}
         </div>
       </div>
       <div className="form-group text-center text-larger">

--- a/src/pages/login/sign-up.jsx
+++ b/src/pages/login/sign-up.jsx
@@ -88,6 +88,8 @@ var SignUp = React.createClass({
   onSubmit: function (e) {
     e.preventDefault();
 
+    document.activeElement.blur();
+
     var errors = this.getValidationErrors();
     if (Object.keys(errors).length > 0) {
       return;

--- a/src/pages/login/sign-up.jsx
+++ b/src/pages/login/sign-up.jsx
@@ -110,7 +110,7 @@ var SignUp = React.createClass({
           window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Error');
         }
         this.setState({globalError: err.message || 'Something went wrong.' });
-        return reportError("Error while trying to sign up", err);
+        return;
       }
 
       this.replaceState(this.getInitialState());

--- a/src/tests/api.test.js
+++ b/src/tests/api.test.js
@@ -33,6 +33,9 @@ function resetMocks(xhrMock) {
         },
         token: 'fakeToken'
       };
+    },
+    isNetworkAvailable: function () {
+      return true;
     }
   };
   api = proxyquire('../lib/api', {
@@ -150,7 +153,7 @@ describe('api', function () {
       });
     });
 
-    it('should return an error with a message for non-200 auth response', function (done) {
+    it('should return correct error message for 400 auth response', function (done) {
 
       resetMocks(createMockXhr({
         '/authenticate': {
@@ -163,7 +166,7 @@ describe('api', function () {
       }));
 
       api.authenticate({json: {username: 'k88', password: '123'}}, function (err, data) {
-        should.deepEqual(err, {message: 'Wrong!'});
+        should.equal(err.message, api.ERROR_MESSAGES.wrong_username_password);
         done();
       });
     });

--- a/src/tests/api.test.js
+++ b/src/tests/api.test.js
@@ -228,6 +228,22 @@ describe('api', function () {
       });
     });
 
+    it('should return correct error message if offline', function (done) {
+
+      resetMocks(createMockXhr({
+        '/authenticate': {
+          statusCode: 0
+        }
+      }));
+
+      global.window.Platform.isNetworkAvailable = () => false;
+
+      api.signUp({json: {username: 'k88', password: '123', email: 'k88@foo.com'}}, function (err, data) {
+        should.equal(err.message, api.ERROR_MESSAGES.offline_sign_up);
+        done();
+      });
+    });
+
     it('should return an error for non-200 response', function (done) {
       resetMocks(createMockXhr({
         '/sign-up': {

--- a/src/tests/api.test.js
+++ b/src/tests/api.test.js
@@ -39,7 +39,8 @@ function resetMocks(xhrMock) {
     }
   };
   api = proxyquire('../lib/api', {
-    xhr: xhrMock || function() {}
+    xhr: xhrMock || function() {},
+    './platform': global.window.Platform
   });
   api.AUTHENTICATE_URI = '/authenticate';
   api.USER_URI = '/user';
@@ -149,6 +150,22 @@ describe('api', function () {
       api.authenticate({user: {foo: 'bar'}, json: {username: 'k88', password: '123'}}, function (err, data) {
         should.equal(wasCalled, false);
         should.deepEqual(data, {token: 'foo', user: {foo: 'bar'}});
+        done();
+      });
+    });
+
+    it('should return correct error message if offline', function (done) {
+
+      resetMocks(createMockXhr({
+        '/authenticate': {
+          statusCode: 0
+        }
+      }));
+
+      global.window.Platform.isNetworkAvailable = () => false;
+
+      api.authenticate({json: {username: 'k88', password: '123'}}, function (err, data) {
+        should.equal(err.message, api.ERROR_MESSAGES.offline_sign_in);
         done();
       });
     });


### PR DESCRIPTION
- Added a check if for connection via Android and new offline error messages
- Added more specific error handling for XHR errors, 400 errors, and other error errors
- Removed duplicate snack bar errors

I did not provide localized versions of the error messages in this patch, although I did move them to a an object on api. I'd prefer to do this as a follow up (filed #459) since there a number of ways we could do it, and i'd like to discuss what the best approach is
