### PR TITLE
initial refactor of setView

### DIFF
--- a/src/components/basic-element/basic-element.jsx
+++ b/src/components/basic-element/basic-element.jsx
@@ -9,6 +9,7 @@ var classes = require('classnames');
 var Spec = require('../../lib/spec');
 var touchhandler = require("../../lib/touchhandler");
 var dispatcher = require('../../lib/dispatcher');
+var platform = require('../../lib/platform');
 
 var PAGE_WIDTH = 320;
 var PAGE_HEIGHT = 440;
@@ -145,9 +146,7 @@ var BasicElement = React.createClass({
 
   onLinkDestClick: function () {
     if (this.props.targetPageId) {
-      if (window.Platform) {
-        window.Platform.setView(`/users/${this.props.targetUserId}/projects/${this.props.targetProjectId}/pages/${this.props.targetPageId}`);
-      }
+      platform.changeViewImmediately(`/users/${this.props.targetUserId}/projects/${this.props.targetProjectId}/pages/${this.props.targetPageId}`);
     } else {
       dispatcher.fire('linkDestinationClicked', this.props);
     }

--- a/src/components/color-group/color-group.jsx
+++ b/src/components/color-group/color-group.jsx
@@ -1,5 +1,6 @@
 var React = require('react/addons');
 var classNames = require('classnames');
+var platform = require('../../lib/platform');
 
 var ColorGroup = React.createClass({
   statics: {
@@ -42,14 +43,10 @@ var ColorGroup = React.createClass({
       this.props.onChange(this.valueLink.value);
     }
 
-    if (!window.Platform) {
-      return;
-    }
-
     e.preventDefault();
 
     var launch = () => {
-      window.Platform.setView(this.getTinkerUrl());
+      platform.changeViewImmediately(this.getTinkerUrl());
     };
 
     if (this.props.onLaunchTinker) {

--- a/src/components/link/link.jsx
+++ b/src/components/link/link.jsx
@@ -1,5 +1,6 @@
 var React = require('react');
 var assign = require('react/lib/Object.assign');
+var platform = require('../../lib/platform');
 
 var Link = React.createClass({
   getDefaultProps: function () {
@@ -12,19 +13,17 @@ var Link = React.createClass({
     var props = assign({}, this.props, {
       className,
       onClick: (e) => {
-        if (window.Platform) {
-          e.preventDefault();
+        e.preventDefault();
 
-          // if there is a pre-navigation handling hook, call that before continuing
-          if (this.props.preNavigation && typeof this.props.preNavigation === 'function') {
-            this.props.preNavigation();
-          }
+        // if there is a pre-navigation handling hook, call that before continuing
+        if (this.props.preNavigation && typeof this.props.preNavigation === 'function') {
+          this.props.preNavigation();
+        }
 
-          if (this.props.external) {
-            window.Platform.openExternalUrl(this.props.external);
-          } else if (this.props.url) {
-            window.Platform.setView(this.props.url);
-          }
+        if (this.props.external) {
+          platform.openExternalUrl(this.props.external);
+        } else if (this.props.url) {
+          platform.changeViewImmediately(this.props.url);
         }
       }
     });

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -93,7 +93,18 @@ Platform.prototype.setMemStorage = function(key, value, global) {
 // Navigation
 // -----------------------------------------------------------------------------
 
-Platform.prototype.setView = function(uri) {
+Platform.prototype.changeViewImmediately = function(uri) {
+  window.location.href = uri;
+};
+
+Platform.prototype.changeViewWithRouteData = function(uri, data) {
+  // TODO: this does something meaningful in Android only.
+  // FIXME: should this do something meaninngful outside of Android?
+  window.location.href = uri;
+};
+
+Platform.prototype.changeViewWithCaching = function(uri, cachegKey, data) {
+  // TODO: perform java caching here
   window.location.href = uri;
 };
 
@@ -182,7 +193,7 @@ Platform.prototype.isDebugBuild = function() {
 // -----------------------------------------------------------------------------
 
 Platform.prototype.isNetworkAvailable = function() {
-  // @todo - the android method is synchronous, we need to do the browser chekc async 
+  // @todo - the android method is synchronous, we need to do the browser chekc async
   return true;
 };
 

--- a/src/pages/element/link-editor.jsx
+++ b/src/pages/element/link-editor.jsx
@@ -48,7 +48,7 @@ var LinkEditor = React.createClass({
         console.error('There was an error updating the element', err);
       }
       var pickerView = `/users/${this.props.params.user}/projects/${this.props.params.project}/link`;
-      platform.setView(pickerView, JSON.stringify(metadata));
+      platform.changeViewWithRouteData(pickerView, JSON.stringify(metadata));
     };
 
     var java = platform.getAPI();

--- a/src/pages/login/sign-in.jsx
+++ b/src/pages/login/sign-in.jsx
@@ -1,5 +1,6 @@
 var React = require('react/addons');
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 var keyboard = require('../../lib/keyboard');
 
 var FormInput = require('./form-input.jsx');
@@ -90,21 +91,17 @@ var SignIn = React.createClass({
     api.authenticate({json}, (err, data) => {
       this.props.setParentState({loading: false});
       if (err) {
-        if (window.Platform) {
-          window.Platform.trackEvent('Login', 'Sign In', 'Sign In Error');
-        }
-        this.setState({globalError: err.message || 'Something went wrong.'});
+        platform.trackEvent('Login', 'Sign In', 'Sign In Error');
         console.log(err);
         return;
       }
 
       this.replaceState(this.getInitialState());
 
-      if (window.Platform) {
-        window.Platform.trackEvent('Login', 'Sign In', 'Sign In Success');
-        window.Platform.setUserSession(JSON.stringify(data));
-        window.Platform.setView('/main');
-      }
+      platform.trackEvent('Login', 'Sign In', 'Sign In Success');
+      platform.setUserSession(JSON.stringify(data));
+      platform.changeViewImmediately('/main');
+
     });
   },
 

--- a/src/pages/login/sign-up.jsx
+++ b/src/pages/login/sign-up.jsx
@@ -1,6 +1,7 @@
 var React = require('react/addons');
 var reportError = require('../../lib/errors');
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 var keyboard = require('../../lib/keyboard');
 
 var FormInput = require('./form-input.jsx');
@@ -108,20 +109,15 @@ var SignUp = React.createClass({
     api.signUp({json: options}, (err, data) => {
       this.props.setParentState({loading: false});
       if (err) {
-        if (window.Platform) {
-          window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Error');
-        }
-        this.setState({globalError: err.message || 'Something went wrong.' });
+        platform.trackEvent('Login', 'Sign Up', 'Sign Up Error');
         return;
       }
 
       this.replaceState(this.getInitialState());
 
-      if (window.Platform) {
-        window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Success');
-        window.Platform.setUserSession(JSON.stringify(data));
-        window.Platform.setView('/main');
-      }
+      platform.trackEvent('Login', 'Sign Up', 'Sign Up Success');
+      platform.setUserSession(JSON.stringify(data));
+      platform.changeViewImmediately('/main');
     });
   },
 

--- a/src/pages/make/make.jsx
+++ b/src/pages/make/make.jsx
@@ -128,7 +128,7 @@ var Make = React.createClass({
         loading: false,
         projects: this.state.projects.concat([project])
       }, function() {
-        platform.setView('/users/' + user.id + '/projects/' + project.id);
+        platform.changeViewImmediately('/users/' + user.id + '/projects/' + project.id);
       });
     });
 
@@ -137,7 +137,7 @@ var Make = React.createClass({
   logout: function () {
     platform.trackEvent('Login', 'Sign Out', 'Sign Out Success');
     platform.clearUserSession();
-    platform.setView('/login/sign-in');
+    platform.changeViewImmediately('/login/sign-in');
   },
 
   cardActionClick: function (e) {

--- a/src/pages/page/page.jsx
+++ b/src/pages/page/page.jsx
@@ -121,7 +121,7 @@ var Page = React.createClass({
       }));
     }
 
-    platform.setView('/users/' + this.state.params.user + '/projects/' + parentProjectID + '/link', JSON.stringify(metadata));
+    platform.changeViewWithRouteData('/users/' + this.state.params.user + '/projects/' + parentProjectID + '/link', JSON.stringify(metadata));
   },
 
   /**

--- a/src/pages/project/remix.js
+++ b/src/pages/project/remix.js
@@ -1,5 +1,6 @@
 var dispatcher = require('../../lib/dispatcher');
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 
 module.exports = {
   componentDidMount: function() {
@@ -28,16 +29,15 @@ module.exports = {
             return console.error('Error remixing project', err);
           }
 
-          if (window.Platform) {
-            window.Platform.setView(
-              `/users/${this.state.user.id}/projects/${projectID}`,
-              JSON.stringify({
-                isFreshRemix: true,
-                title: projectTitle,
-                originalAuthor: moreData.project.author.username
-              })
-            );
-          }
+          platform.changeViewWithRouteData(
+            `/users/${this.state.user.id}/projects/${projectID}`,
+            JSON.stringify({
+              isFreshRemix: true,
+              title: projectTitle,
+              originalAuthor: moreData.project.author.username
+            })
+          );
+
         });
       });
     };


### PR DESCRIPTION
partially addresses https://github.com/mozilla/webmaker-core/issues/451 by doing the initial refactor of the super ambiguous `setView` call to three (currently two actually used) view change calls, each of which is named after _how_ they change the view (immediately, with route data, or with cached data)
