### PR TITLE
DRYing out setView calls with java caching

### DIFF
--- a/src/components/basic-element/basic-element.jsx
+++ b/src/components/basic-element/basic-element.jsx
@@ -9,6 +9,7 @@ var classes = require('classnames');
 var Spec = require('../../lib/spec');
 var touchhandler = require("../../lib/touchhandler");
 var dispatcher = require('../../lib/dispatcher');
+var platform = require('../../lib/platform');
 
 var PAGE_WIDTH = 320;
 var PAGE_HEIGHT = 440;
@@ -145,9 +146,7 @@ var BasicElement = React.createClass({
 
   onLinkDestClick: function () {
     if (this.props.targetPageId) {
-      if (window.Platform) {
-        window.Platform.setView(`/users/${this.props.targetUserId}/projects/${this.props.targetProjectId}/pages/${this.props.targetPageId}`);
-      }
+      platform.changeViewImmediately(`/users/${this.props.targetUserId}/projects/${this.props.targetProjectId}/pages/${this.props.targetPageId}`);
     } else {
       dispatcher.fire('linkDestinationClicked', this.props);
     }

--- a/src/components/color-group/color-group.jsx
+++ b/src/components/color-group/color-group.jsx
@@ -1,5 +1,6 @@
 var React = require('react/addons');
 var classNames = require('classnames');
+var platform = require('../../lib/platform');
 
 var ColorGroup = React.createClass({
   statics: {
@@ -42,14 +43,10 @@ var ColorGroup = React.createClass({
       this.props.onChange(this.valueLink.value);
     }
 
-    if (!window.Platform) {
-      return;
-    }
-
     e.preventDefault();
 
     var launch = () => {
-      window.Platform.setView(this.getTinkerUrl());
+      platform.changeViewImmediately(this.getTinkerUrl());
     };
 
     if (this.props.onLaunchTinker) {

--- a/src/components/link/link.jsx
+++ b/src/components/link/link.jsx
@@ -1,5 +1,6 @@
 var React = require('react');
 var assign = require('react/lib/Object.assign');
+var platform = require('../../lib/platform');
 
 var Link = React.createClass({
   getDefaultProps: function () {
@@ -12,19 +13,17 @@ var Link = React.createClass({
     var props = assign({}, this.props, {
       className,
       onClick: (e) => {
-        if (window.Platform) {
-          e.preventDefault();
+        e.preventDefault();
 
-          // if there is a pre-navigation handling hook, call that before continuing
-          if (this.props.preNavigation && typeof this.props.preNavigation === 'function') {
-            this.props.preNavigation();
-          }
+        // if there is a pre-navigation handling hook, call that before continuing
+        if (this.props.preNavigation && typeof this.props.preNavigation === 'function') {
+          this.props.preNavigation();
+        }
 
-          if (this.props.external) {
-            window.Platform.openExternalUrl(this.props.external);
-          } else if (this.props.url) {
-            window.Platform.setView(this.props.url);
-          }
+        if (this.props.external) {
+          platform.openExternalUrl(this.props.external);
+        } else if (this.props.url) {
+          platform.changeViewImmediately(this.props.url);
         }
       }
     });

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -93,7 +93,18 @@ Platform.prototype.setMemStorage = function(key, value, global) {
 // Navigation
 // -----------------------------------------------------------------------------
 
-Platform.prototype.setView = function(uri) {
+Platform.prototype.changeViewImmediately = function(uri) {
+  window.location.href = uri;
+};
+
+Platform.prototype.changeViewWithRouteData = function(uri, data) {
+  // TODO: this does something meaningful in Android only.
+  // FIXME: should this do something meaninngful outside of Android?
+  window.location.href = uri;
+};
+
+Platform.prototype.changeViewWithCaching = function(uri, cachegKey, data) {
+  // TODO: perform java caching here
   window.location.href = uri;
 };
 
@@ -182,7 +193,7 @@ Platform.prototype.isDebugBuild = function() {
 // -----------------------------------------------------------------------------
 
 Platform.prototype.isNetworkAvailable = function() {
-  // @todo - the android method is synchronous, we need to do the browser chekc async 
+  // @todo - the android method is synchronous, we need to do the browser chekc async
   return true;
 };
 

--- a/src/pages/element/link-editor.jsx
+++ b/src/pages/element/link-editor.jsx
@@ -48,7 +48,7 @@ var LinkEditor = React.createClass({
         console.error('There was an error updating the element', err);
       }
       var pickerView = `/users/${this.props.params.user}/projects/${this.props.params.project}/link`;
-      platform.setView(pickerView, JSON.stringify(metadata));
+      platform.changeViewWithRouteData(pickerView, JSON.stringify(metadata));
     };
 
     var java = platform.getAPI();

--- a/src/pages/element/link-editor.jsx
+++ b/src/pages/element/link-editor.jsx
@@ -43,34 +43,14 @@ var LinkEditor = React.createClass({
       userID: this.props.params.user
     };
 
-    var handler = (err, data) => {
-      if (err) {
-        console.error('There was an error updating the element', err);
-      }
-      var pickerView = `/users/${this.props.params.user}/projects/${this.props.params.project}/link`;
-      platform.changeViewWithRouteData(pickerView, JSON.stringify(metadata));
-    };
-
-    var java = platform.getAPI();
-
-    if(java) {
-      java.queue("link-element", JSON.stringify({
+    platform.changeViewWithCaching(
+      `/users/${this.props.params.user}/projects/${this.props.params.project}/link`,
+      "link-element",
+      JSON.stringify({
         data: expanded,
         metadata: metadata
-      }));
-      handler();
-    }
-
-    else {
-      api({
-        method: 'patch',
-        uri: `/users/${metadata.userID}/projects/${metadata.projectID}/pages/${metadata.pageID}/elements/${metadata.elementID}`,
-        json: {
-          attributes: expanded.attributes,
-          styles: expanded.styles
-        }
-      }, handler);
-    }
+      })
+    );
   },
   render: function () {
     return (

--- a/src/pages/login/sign-in.jsx
+++ b/src/pages/login/sign-in.jsx
@@ -1,5 +1,6 @@
 var React = require('react/addons');
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 var keyboard = require('../../lib/keyboard');
 
 var FormInput = require('./form-input.jsx');
@@ -90,21 +91,17 @@ var SignIn = React.createClass({
     api.authenticate({json}, (err, data) => {
       this.props.setParentState({loading: false});
       if (err) {
-        if (window.Platform) {
-          window.Platform.trackEvent('Login', 'Sign In', 'Sign In Error');
-        }
-        this.setState({globalError: err.message || 'Something went wrong.'});
+        platform.trackEvent('Login', 'Sign In', 'Sign In Error');
         console.log(err);
         return;
       }
 
       this.replaceState(this.getInitialState());
 
-      if (window.Platform) {
-        window.Platform.trackEvent('Login', 'Sign In', 'Sign In Success');
-        window.Platform.setUserSession(JSON.stringify(data));
-        window.Platform.setView('/main');
-      }
+      platform.trackEvent('Login', 'Sign In', 'Sign In Success');
+      platform.setUserSession(JSON.stringify(data));
+      platform.changeViewImmediately('/main');
+
     });
   },
 

--- a/src/pages/login/sign-up.jsx
+++ b/src/pages/login/sign-up.jsx
@@ -1,6 +1,7 @@
 var React = require('react/addons');
 var reportError = require('../../lib/errors');
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 var keyboard = require('../../lib/keyboard');
 
 var FormInput = require('./form-input.jsx');
@@ -108,20 +109,15 @@ var SignUp = React.createClass({
     api.signUp({json: options}, (err, data) => {
       this.props.setParentState({loading: false});
       if (err) {
-        if (window.Platform) {
-          window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Error');
-        }
-        this.setState({globalError: err.message || 'Something went wrong.' });
+        platform.trackEvent('Login', 'Sign Up', 'Sign Up Error');
         return;
       }
 
       this.replaceState(this.getInitialState());
 
-      if (window.Platform) {
-        window.Platform.trackEvent('Login', 'Sign Up', 'Sign Up Success');
-        window.Platform.setUserSession(JSON.stringify(data));
-        window.Platform.setView('/main');
-      }
+      platform.trackEvent('Login', 'Sign Up', 'Sign Up Success');
+      platform.setUserSession(JSON.stringify(data));
+      platform.changeViewImmediately('/main');
     });
   },
 

--- a/src/pages/make/make.jsx
+++ b/src/pages/make/make.jsx
@@ -128,7 +128,7 @@ var Make = React.createClass({
         loading: false,
         projects: this.state.projects.concat([project])
       }, function() {
-        platform.setView('/users/' + user.id + '/projects/' + project.id);
+        platform.changeViewImmediately('/users/' + user.id + '/projects/' + project.id);
       });
     });
 
@@ -137,7 +137,7 @@ var Make = React.createClass({
   logout: function () {
     platform.trackEvent('Login', 'Sign Out', 'Sign Out Success');
     platform.clearUserSession();
-    platform.setView('/login/sign-in');
+    platform.changeViewImmediately('/login/sign-in');
   },
 
   cardActionClick: function (e) {

--- a/src/pages/page/page.jsx
+++ b/src/pages/page/page.jsx
@@ -121,7 +121,7 @@ var Page = React.createClass({
       }));
     }
 
-    platform.setView('/users/' + this.state.params.user + '/projects/' + parentProjectID + '/link', JSON.stringify(metadata));
+    platform.changeViewWithRouteData('/users/' + this.state.params.user + '/projects/' + parentProjectID + '/link', JSON.stringify(metadata));
   },
 
   /**

--- a/src/pages/project/remix.js
+++ b/src/pages/project/remix.js
@@ -1,5 +1,6 @@
 var dispatcher = require('../../lib/dispatcher');
 var api = require('../../lib/api');
+var platform = require('../../lib/platform');
 
 module.exports = {
   componentDidMount: function() {
@@ -28,16 +29,15 @@ module.exports = {
             return console.error('Error remixing project', err);
           }
 
-          if (window.Platform) {
-            window.Platform.setView(
-              `/users/${this.state.user.id}/projects/${projectID}`,
-              JSON.stringify({
-                isFreshRemix: true,
-                title: projectTitle,
-                originalAuthor: moreData.project.author.username
-              })
-            );
-          }
+          platform.changeViewWithRouteData(
+            `/users/${this.state.user.id}/projects/${projectID}`,
+            JSON.stringify({
+              isFreshRemix: true,
+              title: projectTitle,
+              originalAuthor: moreData.project.author.username
+            })
+          );
+
         });
       });
     };

--- a/src/pages/project/setdestination.js
+++ b/src/pages/project/setdestination.js
@@ -17,56 +17,26 @@ module.exports = {
   },
 
   setDestination: function () {
-    var java = platform.getAPI();
+    var cache = platform.getAPI();
+    var payloads = cache.getPayloads("link-element");
+    cache.clearPayloads("link-element");
 
-    // If we have java caching available, there should be a link-element in cache
-    if(java) {
-      var payloads = java.getPayloads("link-element");
-      java.clearPayloads("link-element");
-
+    try {
       var list = JSON.parse(payloads);
+
       var element = types.link.spec.expand(list[0].data);
       element.attributes.targetPageId    = this.state.selectedEl;
       element.attributes.targetProjectId = this.state.params.project;
       element.attributes.targetUserId    = this.state.params.user;
 
-      var serialized = JSON.stringify({
-        data: element
-      });
-      java.queue("edit-element", serialized);
+      var serialized = JSON.stringify({ data: element });
+      cache.queue("edit-element", serialized);
       platform.goBack();
     }
 
-    // fall back to the original API way of doing things
-    else {
-
-      var patchedState = this.state.routeData.linkState;
-
-      patchedState = types.link.spec.expand(patchedState);
-
-      // Patch old attributes object to prevent overwritten properties
-      patchedState.attributes.targetPageId = this.state.selectedEl;
-      patchedState.attributes.targetProjectId = this.state.params.project;
-      patchedState.attributes.targetUserId = this.state.params.user;
-
-      this.setState({loading: true});
-      api({
-        method: 'patch',
-        uri: `/users/${this.state.routeData.userID}/projects/${this.state.routeData.projectID}/pages/${this.state.routeData.pageID}/elements/${this.state.routeData.elementID}`,
-        json: {
-          attributes: patchedState.attributes
-        }
-      }, (err, data) => {
-        this.setState({loading: false});
-        if (err) {
-          reportError('There was an error updating the element', err);
-        }
-
-        if (window.Platform) {
-          window.Platform.goBack();
-        }
-      });
+    catch(e) {
+      reportError("Parse error in link-element data");
+      platform.goBack();
     }
-
   }
 };


### PR DESCRIPTION
This starts to DRY out the code that currently does java caching before changing views. Ultimately, all caching calls end up using the same function, with one function call to initiate both the caching and the view change.

This builds on top of https://github.com/mozilla/webmaker-core/pull/569, so the meaningful change here is https://github.com/mozilla/webmaker-core/commit/8442822924ddf59969896cbc95f75da7b92b8a09
