### PR TITLE
Revert "v1.3.2"

### DIFF
--- a/src/pages/make/make.jsx
+++ b/src/pages/make/make.jsx
@@ -197,10 +197,10 @@ var Make = React.createClass({
         </button>
         {cards}
         <Loading on={this.state.loading} />
-        <Link url="/style-guide" hidden={!platform.isDebugBuild()} className="btn btn-create btn-block btn-teal">
+        <Link url="/style-guide" hidden={platform.isDebugBuild()} className="btn btn-create btn-block btn-teal">
            {this.getIntlMessage('open_style_guide')}
         </Link>
-        <button hidden={!platform.isDebugBuild()} onClick={platform.resetSharedPreferences()} className="btn btn-create btn-block btn-teal">
+        <button hidden={platform.isDebugBuild()} onClick={platform.resetSharedPreferences()} className="btn btn-create btn-block btn-teal">
           {this.getIntlMessage('reset_share_preferences')}
         </button>
       </div>


### PR DESCRIPTION
Reverts mozilla/webmaker-core#663

This shouldn't have been changed, the debug flag should be in BuildInfo within the APK project.

Edit: When platform got refactored out the ! was removed, making this a valid fix.
