### PR TITLE
Make Google Fonts HTTPS, fix cross platform bug

### DIFF
--- a/src/components/basic-element/basic-element.less
+++ b/src/components/basic-element/basic-element.less
@@ -1,12 +1,13 @@
 .el-container {
   position: absolute;
   height: 1px;
-  width: 1px;
+  width: 100%;
   left: 50%;
   top: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-left: -50%;
 
   .icon {
     position: relative;
@@ -28,7 +29,6 @@
 .el {
   flex-shrink: 0;
 
-  padding: 10px;
   user-select: none;
 
   position: relative;
@@ -57,13 +57,12 @@
 */
 
 .el {
-
+  box-sizing: content-box;
   // Text
   &.el-text {
     max-width: 320px;
     p {
       margin: 0;
-      padding: 0 10px;
     }
   }
 
@@ -83,12 +82,5 @@
       display: block;
       max-width: 300px;
     }
-  }
-}
-
-// Slightly hacky: this improves rendering consistency x-browser
-#map.play {
-  .el.el-text p {
-    width: 320px;
   }
 }

--- a/src/components/basic-element/types/text.jsx
+++ b/src/components/basic-element/types/text.jsx
@@ -15,7 +15,7 @@ var spec = new Spec('text', assign({
   fontFamily: {
     category: 'styles',
     validation: React.PropTypes.string,
-    default: 'sans-serif'
+    default: 'Roboto'
   },
   color: {
     category: 'styles',

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -10,6 +10,6 @@
   <div id="app"></div>
   <script src="../../js/Intl.js"></script>
   <script src="{{ js_src }}"></script>
-  <link href="http://fonts.googleapis.com/css?family=Bitter|Roboto|Pacifico" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Bitter|Roboto|Pacifico" rel="stylesheet">
 </body>
 </html>


### PR DESCRIPTION
Addresses some font weirdness that might be relevant to #440, #706, #733, and #734 

Hard to say if this will completely solve them without it webmaker-browser being updated for React 0.14.
