### PR TITLE
Don't add default link text color

### DIFF
--- a/src/components/basic-element/types/link.jsx
+++ b/src/components/basic-element/types/link.jsx
@@ -50,7 +50,6 @@ var spec = new Spec('link', assign({
   color: {
     category: 'styles',
     validation: React.PropTypes.string,
-    default: '#FFF',
     editor: 'color'
   },
   boxShadow: {
@@ -95,7 +94,7 @@ var Link = React.createClass({
       borderRadius: props.borderRadius,
       backgroundColor: props.backgroundColor,
       border: `1px solid ${darken(props.backgroundColor, 0.4)}`,
-      color: props.color,
+      color: props.color || getContrastingColor(props.backgroundColor),
       fontFamily: props.fontFamily,
       whiteSpace: props.whiteSpace,
       boxShadow: `inset 0px 2px 0px rgba(255, 255, 255, ${0.3*shadowOpacity})`


### PR DESCRIPTION
Rely on existing getContrastingColor method until user specifies color to use

Closes #715, but waiting on confirmation of expected behavior
