### PR TITLE
Make background elements not come to front on first tap

### DIFF
--- a/src/components/basic-element/basic-element.jsx
+++ b/src/components/basic-element/basic-element.jsx
@@ -88,11 +88,6 @@ var BasicElement = React.createClass({
     dnode.addEventListener("touchmove", touchHandler.panmove);
     dnode.addEventListener("touchend", touchHandler.endmark);
 
-    // Handle taps
-    dnode.addEventListener("touchstart", touchHandler.tapStart);
-    dnode.addEventListener("touchmove", touchHandler.tapMove);
-    dnode.addEventListener("touchend", touchHandler.tapEnd);
-
     // the overlay handles all the two finger touch events
     var onode = this.refs.overlay;
     onode.addEventListener("touchstart", touchHandler.secondFinger);
@@ -137,7 +132,7 @@ var BasicElement = React.createClass({
     var scaledHeight = (elStyleWrapper.clientHeight - (parseInt(paddingTop, 10) + parseInt(paddingBottom, 10))) * this.props.scale;
 
     if ( scaledWidth > 200 || scaledHeight > 200 ) {
-      elStyleWrapper.style.padding = `0`;
+      elStyleWrapper.style.padding = `1px`;
     } else {
       //Account for shrinking touch target by increasing padding relative to scale
       elStyleWrapper.style.padding = `${20/this.props.scale}px`;
@@ -213,7 +208,7 @@ var BasicElement = React.createClass({
     );
 
     var wrapperStyle = Spec.propsToPosition(this.getInitialState());
-
+    
     // Note: we're rending the element off of this.props, NOT this.state:
     return (
       <div className="el-wrapper">
@@ -259,6 +254,7 @@ var BasicElement = React.createClass({
     x = (x > edgeX) ? edgeX : (x < -edgeX) ? -edgeX : x;
     y = (y > edgeY) ? edgeY : (y < -edgeY) ? -edgeY : y;
 
+    //In the future, to improve performance perhaps we can update position while dragging but not within the react state
     this.setState({ x: x, y: y }, this.onUpdate);
   },
 

--- a/src/pages/page/page.jsx
+++ b/src/pages/page/page.jsx
@@ -280,7 +280,7 @@ var Page = React.createClass({
       var elements = this.state.elements;
       var element = elements[elementId];
       var highestIndex = this.getHighestIndex();
-      if (element.zIndex !== highestIndex) {
+      if (this.state.currentElementId === this.state.previousElementId && element.zIndex !== highestIndex) {
         element.zIndex = highestIndex + 1;
         this.setState({elements}, function() {
           this.queueEdit(elementId);
@@ -299,8 +299,10 @@ var Page = React.createClass({
       var elements = this.state.elements;
       var element = elements[elementId];
       elements[elementId] = assign(element, newProps);
+      var previousElementId = this.state.currentElementId;
       this.setState({
         elements: elements,
+        previousElementId: previousElementId,
         currentElementId: elementId
       }, function() {
         this.queueEdit(elementId);


### PR DESCRIPTION
Tapping a background element doesn't bring it to the front immediately. Closes #850 
