### PR TITLE
patch to allow -browser to render projects

### DIFF
--- a/src/pages/project/setdestination.js
+++ b/src/pages/project/setdestination.js
@@ -19,12 +19,14 @@ module.exports = {
   componentWillMount: function () {
     var java = platform.getAPI();
 
-    this.props.update({
-      onBackPressed: () => {
-        java.clearPayloads(`link-element`);
-        window.Platform.goBack();
-      }
-    });
+    if (java) {
+      this.props.update({
+        onBackPressed: () => {
+          java.clearPayloads(`link-element`);
+          window.Platform.goBack();
+        }
+      });
+    }
   },
 
   setDestination: function () {


### PR DESCRIPTION
`webmaker-browser` won't render project properly without this check because of undefined props.

This is needed before we bump the version of `core` on `browser`.
