### PR TITLE
Add left/right padding to text elements

### DIFF
--- a/src/components/basic-element/types/text.jsx
+++ b/src/components/basic-element/types/text.jsx
@@ -57,6 +57,10 @@ var spec = new Spec('text', assign({
   whiteSpace: {
     category: 'styles',
     default: 'pre'
+  },
+  padding: {
+    category: 'styles',
+    default: '0 10px'
   }
 }, Spec.getPositionProps()));
 
@@ -86,7 +90,8 @@ module.exports = React.createClass({
       'textDecoration',
       'textAlign',
       'backgroundColor',
-      'whiteSpace'
+      'whiteSpace',
+      'padding'
     ].forEach(function (prop) {
       style[prop] = props[prop];
     });

--- a/src/components/basic-element/types/textedit.js
+++ b/src/components/basic-element/types/textedit.js
@@ -99,12 +99,13 @@ module.exports = {
       width: "auto",
       height: "auto",
       position: "fixed",
-      padding: "0 2px"
+      padding: "0"
     });
 
     if(this.refs.sizer) {
       var sizer = this.refs.sizer;
       inputStyle.width = sizer.scrollWidth;
+      inputStyle.padding = 0;
     }
 
     return [


### PR DESCRIPTION
Closes #908 

I added the padding to the element itself, so it will render consistently across platforms. The previous problem was padding on the wrapper elements/not on the text element.
