### PR TITLE
Partial revert "Preserve whitespace in text..."

### DIFF
--- a/src/components/basic-element/types/text.jsx
+++ b/src/components/basic-element/types/text.jsx
@@ -54,10 +54,6 @@ var spec = new Spec('text', assign({
     validation: React.PropTypes.string,
     default: 'center'
   },
-  whiteSpace: {
-    category: 'styles',
-    default: 'pre'
-  },
   padding: {
     category: 'styles',
     default: '0 10px'
@@ -90,7 +86,6 @@ module.exports = React.createClass({
       'textDecoration',
       'textAlign',
       'backgroundColor',
-      'whiteSpace',
       'padding'
     ].forEach(function (prop) {
       style[prop] = props[prop];


### PR DESCRIPTION
This partially reverts commit 55fe52aa47936a022278bb8256976cc6b29c94bd.
# Conflicts:
# src/components/basic-element/types/text.jsx

This caused an issue with long text blocks

Closes #961. Got overzealous with the `white-space: pre`
