### PR TITLE
Remove beta from Webmaker urls

### DIFF
--- a/src/pages/project-settings/project-settings.jsx
+++ b/src/pages/project-settings/project-settings.jsx
@@ -62,7 +62,7 @@ var ProjectSettings = React.createClass({
 
   render: function () {
     var creativeCommon = (<Link external="https://creativecommons.org/licenses/by-sa/3.0/">{this.getIntlMessage('ccAttribution')}</Link>);
-    var termsOfUseLink = (<Link external="https://beta.webmaker.org/#/legal">{this.getIntlMessage('ccTermsOfUse')}</Link>);
+    var termsOfUseLink = (<Link external="https://webmaker.org/#/legal">{this.getIntlMessage('ccTermsOfUse')}</Link>);
 
     // TODO: TextInput is using `id` as a prop to indicate what state property to use for linkState
     // This is incredibly confusing.


### PR DESCRIPTION
Removes the "beta" segment from all Webmaker urls within webmaker-core.

Work towards finishing #1012

cc: @xmatthewx @alanmoo 
